### PR TITLE
If people with wanted level quit the game, their wanted level will come back as soon as they rejoin the server

### DIFF
--- a/suggestions/Gameplay/Keeping_wanted_level_even_after_quitting
+++ b/suggestions/Gameplay/Keeping_wanted_level_even_after_quitting
@@ -1,0 +1,11 @@
+**Your ingame name:** [Lsrcr]Playa
+**Suggestion title:** Keeping the Wanted Level Even after quitting the game
+**Suggestion description:** 
+This suggestion was discussed with other members of the community and what it basically means is that when a criminal quits the game and re joins (whenever - no particular time frame - he could join under 30 minutes or he could rejoin after an year) his wanted level will stay the same. 
+Hence quitting and rejoining the game will no longer remove your wanted level and will not allow you to escape from cops. 
+We can add a few spawn points for criminals such as Glen Park, Idlewood, Jefferson, East Los Santos, Market etc. Even if they select groups/factions while spawning, they will just spawn at the place with the old skin and the same wanted level.
+**Suggestion pictures:** None
+**Suggestion benefits:** A lot of benefits: 1. criminals dont get rid of their wanted levels unless they: Either die on their own (gas station, jumping off a roof etc) or they get killed/ar by other criminals/cops respectively.
+2. The number of crimes go up
+3. A better gameplay 
+**Suggestion side-effects:** No side effect known for now


### PR DESCRIPTION
This gameplay suggestion suggests the following: 
If a person with a wanted level quits the game and he rejoins (no matter when - could be under 30 minutes or could be an year), he will still have his/wanted level thus promotions a better and a fair gameplay. Open the suggestion to see a detailed description of the same. 